### PR TITLE
AGDIGGER-78 - allow to use untrusted TLS

### DIFF
--- a/bin/digkins.js
+++ b/bin/digkins.js
@@ -5,6 +5,9 @@ require('yargonaut')
   .helpStyle('green')
   .errorsStyle('red');
 
+require("../lib/util/sslSetup")
+  .setupSSLConnections();
+
 var yargs = require('yargs');
 
 yargs.commandDir("../lib/commands")

--- a/lib/api/createJob.js
+++ b/lib/api/createJob.js
@@ -3,6 +3,7 @@ const path = require('path');
 const _ = require('underscore');
 const authHelper = require("../util/auth");
 const Jenkins = require('jenkins');
+
 /**
  *  Create jenkins job
  */

--- a/lib/commands/login.js
+++ b/lib/commands/login.js
@@ -1,6 +1,7 @@
 // Login into jenkins command
 const conf = require("../util/config");
 const logger = require("../util/logger");
+const sslSetup = require("../util/sslSetup");
 const prompt = require('readline-sync');
 
 const infoApi = require("../api/jenkinsInfo");
@@ -8,9 +9,13 @@ const infoApi = require("../api/jenkinsInfo");
 exports.command = 'login <url> [user] [password]';
 exports.aliases = ["setup", "init"];
 exports.describe = 'Setup jenkins credentials and login into jenkins';
-exports.builder = yargs =>
-   yargs.count('verbose').alias('v', 'verbose')
-;
+exports.builder = yargs => {
+  return yargs.count('verbose')
+    .alias('v', 'verbose')
+    .describe("skip-tls-check", "Skip checking TLS certificates when connecting to server")
+    .default("skip-tls-check", false);
+}
+
 exports.handler = argv => {
   if (!argv.user) {
     argv.user = prompt.question('Username: ');
@@ -18,6 +23,10 @@ exports.handler = argv => {
   if (!argv.password) {
     argv.password = prompt.question('Password: ',{ hideEchoBack: true});
   }
+  
+  const untrustedTLS = argv["skip-tls-check"];
+  sslSetup.allowUnstrustedSSLConnections(untrustedTLS);
+  
   const auth = {
     url: argv.url,
     user: argv.user,

--- a/lib/util/sslSetup.js
+++ b/lib/util/sslSetup.js
@@ -1,0 +1,30 @@
+const conf = require("./config");
+
+// Configuration key used to allow untrusted certificates
+var CONFIG_KEY = "acceptUntrustedSSL";
+
+/**
+ * Configures ssl connections
+ */
+module.exports = {
+    /**
+     * Enable unauthorized ssl certs if configured by user
+     */
+    setupSSLConnections: () => {
+        if (conf.get(CONFIG_KEY)) {
+            process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+        }
+    },
+
+    /**
+     * Setup ssl configuration to allow untrusted connection
+     */
+    allowUnstrustedSSLConnections: (allowed) => {
+        conf.set(CONFIG_KEY, allowed);
+        console.log("test" + allowed)
+        if (allowed) {
+            process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+        }
+    }
+};
+


### PR DESCRIPTION
## Motivation

Allow developers to connect our cmd tooling to local oc cluster. 
Without this change developers would not be able to login to their local instance

## Verification
 Get usage
`digkins.js login`

Login
`digkins.js login https://jenkins-jenkins.192.168.2.194.xip.io admin --skip-tls-check`

Review @luigizuccarelli @aliok 