### PR TITLE
AGDIGGER-91 - fixed finished message

### DIFF
--- a/lib/api/streamLogs.js
+++ b/lib/api/streamLogs.js
@@ -31,7 +31,7 @@ module.exports = (auth, jobName, queueNumber, writter, callback) => {
     });
 
     logStream.on('end', function() {
-      writter.log('Build finished'.gray);
+      writter.log('Finished streaming logs');
       callback(err, data);
     });
   });


### PR DESCRIPTION
Small bugfix for log message. `undefined` was logged due to missing color library (it needs to be added explicitly) 

Quick review @luigizuccarelli @omatskiv