### PR TITLE
AGDIGGER-56 - change logging endpoint to use build number

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,8 @@ module.exports = function(grunt) {
       test: {
         options: {
           reporter: 'spec',
-          quiet: false, 
-          clearRequireCache: false, // Optionally clear the require cache before running tests (defaults to false) 
+          quiet: false,
+          clearRequireCache: false,
           noFail: false
         },
         src: ['test/**/*.js']

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,8 @@ module.exports = function(grunt) {
     // Metadata.
     pkg: grunt.file.readJSON('package.json'),
     eslint: {
-      src: ['lib/**/*.js', 'bin/*.js'],
+      options: { fix: true },
+      src: ['lib/**/*.js', 'bin/*.js','test/**/*.js'],
     },
     mochaTest: {
       test: {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ digkins job build my-androip-build
   digkins login <url> [user] [password] 
 
   Stream jenkins logs for triggered build
-  digkins log <job> <queueid>       
+  digkins log <job> <buildNumber>       
   
   Get job artifacts for specified build
   digkins artifact <job> <buildNumber>   

--- a/lib/api/streamLogs.js
+++ b/lib/api/streamLogs.js
@@ -4,38 +4,25 @@ const Jenkins = require('jenkins');
 /**
  *  Stream jenkins logs
  */
-module.exports = (auth, jobName, queueNumber, writter, callback) => {
+module.exports = (auth, jobName, buildNo, writter, callback) => {
   const options = authHelper.createJenkinsOptions(auth.url, auth.user, auth.password);
   const jenkins = Jenkins(options);
-  jenkins.queue.item(queueNumber, function(err, data) {
+  const logStream = jenkins.build.logStream(jobName, buildNo);
+  writter.log(`## Starting streaming build ${buildNo} log`);
+  logStream.on('data', function(text) {
+    if (text) {
+      writter.log(text);
+    }
+  });
+
+  logStream.on('error', function(err) {
     if (err) {
-      callback(err);
-      return;
+      writter.error(err);
     }
-    if (!data.executable || !data.executable.number) {
-      return writter.log("Build did not started yet! Try again later");
-    }
-    const buildNo = data.executable.number;
-    const logStream = jenkins.build.logStream(jobName, buildNo);
-    writter.log(`## Starting streaming build ${buildNo} log`);
-    logStream.on('data', function(text) {
-      if (text) {
-        writter.log(text);
-      }
-    });
+  });
 
-    logStream.on('error', function(err) {
-      if (err) {
-        writter.error(err);
-      }
-    });
-
-    logStream.on('end', function() {
-      writter.log('Finished streaming logs');
-      callback(err, data);
-    });
+  logStream.on('end', function(err) {
+    writter.log('Finished streaming logs');
+    callback(err, buildNo);
   });
 };
-
-
-

--- a/lib/api/streamLogs.js
+++ b/lib/api/streamLogs.js
@@ -9,19 +9,19 @@ module.exports = (auth, jobName, buildNo, writter, callback) => {
   const jenkins = Jenkins(options);
   const logStream = jenkins.build.logStream(jobName, buildNo);
   writter.log(`## Starting streaming build ${buildNo} log`);
-  logStream.on('data', function(text) {
+  logStream.on('data', text => {
     if (text) {
       writter.log(text);
     }
   });
 
-  logStream.on('error', function(err) {
+  logStream.on('error', err => {
     if (err) {
       writter.error(err);
     }
   });
 
-  logStream.on('end', function(err) {
+  logStream.on('end', err => {
     writter.log('Finished streaming logs');
     callback(err, buildNo);
   });

--- a/lib/api/triggerBuild.js
+++ b/lib/api/triggerBuild.js
@@ -5,7 +5,7 @@ const logger = require("../util/logger");
 /**
  *  Trigger jenkins build
  */
-module.exports = (auth, jobName, callback) => {
+module.exports = (auth, jobName, intervalTimeout, callback) => {
   const options = authHelper.createJenkinsOptions(auth.url, auth.user, auth.password);
   const jenkins = Jenkins(options);
   jenkins.job.build(jobName, function(err, queueNumber) {
@@ -18,13 +18,9 @@ module.exports = (auth, jobName, callback) => {
       jenkins.queue.item(queueNumber, function(err, data) {
         if (data && data.executable && data.executable.number) {
           clearInterval(fetchInterval);
-          callback(null,data.executable.number);
+          callback(null, data.executable.number);
         }
       });
-    }, 3000);
+    }, intervalTimeout);
   });
 };
-
-
-
-

--- a/lib/api/triggerBuild.js
+++ b/lib/api/triggerBuild.js
@@ -1,5 +1,6 @@
 const authHelper = require("../util/auth");
 const Jenkins = require('jenkins');
+const logger = require("../util/logger");
 
 /**
  *  Trigger jenkins build
@@ -8,9 +9,22 @@ module.exports = (auth, jobName, callback) => {
   const options = authHelper.createJenkinsOptions(auth.url, auth.user, auth.password);
   const jenkins = Jenkins(options);
   jenkins.job.build(jobName, function(err, queueNumber) {
-    callback(err, queueNumber);
+    if (err) {
+      callback(err);
+      return;
+    }
+    logger.info("Build triggered. Waiting for build number.");
+    const fetchInterval = setInterval(() => {
+      jenkins.queue.item(queueNumber, function(err, data) {
+        if (data && data.executable && data.executable.number) {
+          clearInterval(fetchInterval);
+          callback(null,data.executable.number);
+        }
+      });
+    }, 3000);
   });
 };
+
 
 
 

--- a/lib/commands/jobs/build.js
+++ b/lib/commands/jobs/build.js
@@ -14,7 +14,7 @@ exports.handler = argv => {
   if (!argv.job) {
     argv.job = prompt.question('Jenkins job name: ');
   }
-  triggerBuild(conf.get("auth"), argv.job, function(err, queueNumber) {
+  triggerBuild(conf.get("auth"), argv.job, function(err, buildNumber) {
     if (err) {
       logger.error(`Problem when triggering new build for ${argv.job} job`);
       if (argv.v) {
@@ -22,6 +22,6 @@ exports.handler = argv => {
       }
       return;
     }
-    logger.info(`Build for job ${argv.job} started! Use "log ${argv.job} ${queueNumber}" command to fetch logs`);
+    logger.info(`Build for job ${argv.job} started! Execute 'digkins log ${argv.job} ${buildNumber}' command to fetch logs`);
   });
 };

--- a/lib/commands/jobs/build.js
+++ b/lib/commands/jobs/build.js
@@ -6,15 +6,15 @@ const triggerBuild = require("../../api/triggerBuild");
 
 exports.command = 'build <job>';
 exports.describe = 'Trigger build for Jenkins job';
-exports.builder = yargs =>
-   yargs.count('verbose').alias('v', 'verbose')
-;
+exports.builder = yargs => yargs.count('verbose').alias('v', 'verbose');
+
+const buildNumberPoolingInterval = 3000;
 
 exports.handler = argv => {
   if (!argv.job) {
     argv.job = prompt.question('Jenkins job name: ');
   }
-  triggerBuild(conf.get("auth"), argv.job, function(err, buildNumber) {
+  triggerBuild(conf.get("auth"), argv.job, buildNumberPoolingInterval, function(err, buildNumber) {
     if (err) {
       logger.error(`Problem when triggering new build for ${argv.job} job`);
       if (argv.v) {

--- a/lib/commands/logs.js
+++ b/lib/commands/logs.js
@@ -4,7 +4,7 @@ const logger = require("../util/logger");
 const prompt = require('readline-sync');
 const streamLogs = require("../api/streamLogs");
 
-exports.command = 'log <job> <queueid>';
+exports.command = 'log <job> <buildNumber>';
 exports.describe = 'Stream jenkins logs for triggered build';
 exports.builder = yargs => yargs.count('verbose').alias('v', 'verbose');
 
@@ -12,7 +12,7 @@ exports.handler = argv => {
   if (!argv.job) {
     argv.job = prompt.question('Jenkins job name: ');
   }
-  streamLogs(conf.get("auth"), argv.job, argv.queueid, console, function(err) {
+  streamLogs(conf.get("auth"), argv.job, argv.buildNumber, console, function(err) {
     if (err) {
       logger.error(`Cannot fetch build log for ${argv.job}`);
       if (argv.verbose) {

--- a/package.json
+++ b/package.json
@@ -28,23 +28,24 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "configstore": "^2.1.0",
-    "jenkins": "^0.20.0",
-    "readline-sync": "^1.4.5",
-    "underscore": "^1.8.3",
-    "winston": "^2.3.0",
-    "yargonaut": "^1.1.2",
-    "yargs": "^6.5.0"
+    "configstore": "2.1.0",
+    "jenkins": "0.20.0",
+    "readline-sync": "1.4.5",
+    "underscore": "1.8.3",
+    "winston": "2.3.0",
+    "yargonaut": "1.1.2",
+    "yargs": "6.5.0"
   },
   "engines": {
     "node": ">= 4"
   },
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-mocha-test": "^0.13.2",
-    "gruntify-eslint": "^3.1.0",
-    "mocha": "^3.2.0",
-    "proxyquire": "^1.7.10",
-    "sinon": "^1.17.6"
+    "chai": "3.5.0",
+    "grunt": "1.0.1",
+    "grunt-mocha-test": "0.13.2",
+    "gruntify-eslint": "3.1.0",
+    "mocha": "3.2.0",
+    "proxyquire": "1.7.10",
+    "sinon": "1.17.6"
   }
 }

--- a/test/api/createJobTests.js
+++ b/test/api/createJobTests.js
@@ -1,0 +1,41 @@
+const proxyquire = require('proxyquire');
+const sinon = require("sinon");
+const chai = require("chai");
+const assert = chai.assert;
+
+const auth = {
+  url: "test",
+  user: "user",
+  password: "password"
+};
+
+const jobArgs = {
+  repository: "test",
+  branch: "master",
+  name: "test"
+};
+
+const dataMock = {
+  name: "Test"
+};
+
+const JenkinsWrapper = {
+  job: {
+    create: sinon.stub().yields(null, dataMock)
+  }
+};
+
+const jenkinsStub = () => JenkinsWrapper;
+
+const createJob = proxyquire("../../lib/api/createJob", { 'jenkins': jenkinsStub });
+
+describe('createJob', function() {
+  it('it should return job', function(testFinished) {
+    createJob(auth, jobArgs, function(err, data) {
+      assert.isNotOk(err, "Should not return error");
+      assert.isOk(data, "Should return data");
+      assert.equal(data.name, dataMock.name);
+      testFinished();
+    });
+  });
+});

--- a/test/api/fetchArtifactTests.js
+++ b/test/api/fetchArtifactTests.js
@@ -1,0 +1,33 @@
+const proxyquire = require('proxyquire');
+const sinon = require("sinon");
+const chai = require("chai");
+const assert = chai.assert;
+
+const auth = {
+  url: "test",
+  user: "user",
+  password: "password"
+};
+
+const dataMock = { artifacts: [{ relativePath: "test" }] };
+const JenkinsWrapper = {
+  build: {
+    get: sinon.stub().yields(null, dataMock)
+  }
+};
+
+const jenkinsStub = () => JenkinsWrapper;
+
+var fetchArtifact = proxyquire("../../lib/api/fetchArtifact", { 'jenkins': jenkinsStub });
+
+describe('fetchArtifact', function() {
+  it('it should return artifacts', function(testFinished) {
+    fetchArtifact(auth, "job", 1, function(err, data) {
+      assert.isNotOk(err);
+      assert.isOk(data);
+      assert.equal(data.length, 1);
+      assert.equal(data[0], "test/job/job/1/artifact/test");
+      testFinished();
+    });
+  });
+});

--- a/test/api/jenkinsInfoTests.js
+++ b/test/api/jenkinsInfoTests.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var sinon = require("sinon");
+
+const auth = {
+  url: "test",
+  user: "user",
+  password: "password"
+};
+
+const data = {
+  executable: {
+    number: 1
+  }
+};
+
+const JenkinsWrapper = {
+  info: sinon.stub().yields(null, data)
+};
+
+const jenkinsStub = () =>
+     JenkinsWrapper;
+
+var jenkinsInfo = proxyquire("../../lib/api/jenkinsInfo", { 'jenkins': jenkinsStub });
+
+describe('jenkinsInfo', function() {
+  it('it should return jenkinsInfo', function() {
+    jenkinsInfo(auth, function(err, data) {
+      assert(!err);
+      assert(data);
+    });
+  });
+});

--- a/test/api/streamLogsTests.js
+++ b/test/api/streamLogsTests.js
@@ -1,6 +1,7 @@
-var assert = require('assert');
-var proxyquire = require('proxyquire');
-var sinon = require("sinon");
+const proxyquire = require('proxyquire');
+const sinon = require("sinon");
+const chai = require("chai");
+const assert = chai.assert;
 
 const auth = {
   url: "test",
@@ -20,7 +21,9 @@ const JenkinsWrapper = {
     item: sinon.stub().yields(null, data)
   },
   build: {
-    logStream: () => ({ on: function() { } })
+    logStream: () => ({
+      on: sinon.stub().yields()
+    })
   }
 };
 
@@ -30,17 +33,11 @@ const jenkinsStub = () => JenkinsWrapper;
 var streamLogs = proxyquire("../../lib/api/streamLogs", { 'jenkins': jenkinsStub });
 
 describe('Streaming logs', function() {
-  it('it should return error', function() {
-    JenkinsWrapper.queue.item = sinon.stub().yields("error");
-    streamLogs(auth, jobName, 1, console, function(err) {
-      assert(err);
-    });
-  });
-
-  it('it should stream logs', function() {
+  it('it should stream logs', function(testFinished) {
     JenkinsWrapper.queue.item = sinon.stub().yields(null, data);
     streamLogs(auth, jobName, 1, console, function(err) {
-      assert(!err);
+      assert.isNotOk(err, "Should not return error");
+      testFinished();
     });
   });
 });

--- a/test/api/streamLogsTests.js
+++ b/test/api/streamLogsTests.js
@@ -1,39 +1,46 @@
 var assert = require('assert');
-var proxyquire = require('proxyquire')
+var proxyquire = require('proxyquire');
 var sinon = require("sinon");
 
 const auth = {
   url: "test",
-  user: ".user",
-  password: ".password"
+  user: "user",
+  password: "password"
 };
 
-const jobName = jobName;
-var data = {
+const jobName = "jobName";
+const data = {
   executable: {
-    number: 40
-  }
-}
-var jenkinsStub = () => {
-  return {
-    queue: {
-      item: sinon.stub().yields(null, data)
-    },
-    build: {
-      logStream: () => {
-        return { on: function () {} };
-      }
-    }
+    number: 1
   }
 };
+
+const JenkinsWrapper = {
+  queue: {
+    item: sinon.stub().yields(null, data)
+  },
+  build: {
+    logStream: () => ({ on: function() { } })
+  }
+};
+
+const jenkinsStub = () => JenkinsWrapper;
+
 
 var streamLogs = proxyquire("../../lib/api/streamLogs", { 'jenkins': jenkinsStub });
 
-describe('Streaming logs', function () {
-  it('it should stream logs', function () {
-    var auth = {}
-    streamLogs(auth, jobName, 1, console, function (err) {
+describe('Streaming logs', function() {
+  it('it should return error', function() {
+    JenkinsWrapper.queue.item = sinon.stub().yields("error");
+    streamLogs(auth, jobName, 1, console, function(err) {
+      assert(err);
+    });
+  });
+
+  it('it should stream logs', function() {
+    JenkinsWrapper.queue.item = sinon.stub().yields(null, data);
+    streamLogs(auth, jobName, 1, console, function(err) {
       assert(!err);
-    })
+    });
   });
 });

--- a/test/api/triggerBuildTests.js
+++ b/test/api/triggerBuildTests.js
@@ -9,23 +9,29 @@ const auth = {
   password: "password"
 };
 
-const data = {
+const dataMock = {
   executable: {
     number: 1
   }
 };
 
 const JenkinsWrapper = {
-  info: sinon.stub().yields(null, data)
+  job: {
+    build: sinon.stub().yields(null, {})
+  },
+  queue :{
+    item:sinon.stub().yields(null, dataMock)
+  }
 };
+
 
 const jenkinsStub = () => JenkinsWrapper;
 
-var jenkinsInfo = proxyquire("../../lib/api/jenkinsInfo", { 'jenkins': jenkinsStub });
+var triggerBuild = proxyquire("../../lib/api/triggerBuild", { 'jenkins': jenkinsStub });
 
-describe('jenkinsInfo', function() {
-  it('it should return jenkinsInfo', function(testFinished) {
-    jenkinsInfo(auth, function(err, data) {
+describe('triggerBuild', function() {
+  it('it should trigger build', function(testFinished) {
+    triggerBuild(auth, "job", 10, function(err, data) {
       assert.isNotOk(err, "Should not return error");
       assert.isOk(data, "Should return data");
       testFinished();


### PR DESCRIPTION
## Motivation

Align node.js implementation to use build number instead of queue number as in java client.

