### PR TITLE
Enable client usage as a dependency

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  createJob: require('./createJob.js'),
+  fetchArtifact: require('./fetchArtifact.js'),
+  jenkinsInfo: require('./jenkinsInfo.js'),
+  streamLogs: require('./streamLogs.js'),
+  triggerBuild: require('./triggerBuild')
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aerogear-digger-node-client",
   "version": "1.0.0",
   "description": "AeroGear Digger Node client",
-  "main": "./bin/digger.js",
+  "main": "./lib/api/index.js",
   "bin": {
     "digger": "./bin/digger.js"
   },


### PR DESCRIPTION
This changes enable anyone to `require('aerogear-digger-node-client');` as a dependency.